### PR TITLE
Mark as abandoned, superseded by smartassert/dom-identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,5 +53,6 @@
         "allow-plugins": {
             "phpstan/extension-installer": true
         }
-    }
+    },
+    "abandoned": "smartassert/dom-identifier"
 }


### PR DESCRIPTION
Fixes #82